### PR TITLE
Update with macOS Monterey launchctl subcommands

### DIFF
--- a/launchctl-completion.bash
+++ b/launchctl-completion.bash
@@ -52,7 +52,7 @@ _launchctl ()
 	local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
 	# Subcommand list
-	local subcommands="load unload submit remove start stop list help"
+	local subcommands="bootstrap bootout enable disable kickstart attach debug kill blame print print-cache print-disabled plist procinfo hostinfo resolveport limit runstats examine config dumpstate dumpjpcategory reboot bootshell load unload remove list start stop setenv unsetenv getenv bsexec asuser submit managerpid manageruid managername error variant version help"
 	[[ ${COMP_CWORD} -eq 1 ]] && {
 		COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
 		return


### PR DESCRIPTION
I pulled this completion into my local collection and realized it was missing some commands, so I did a quick copy/paste of `launchctl`'s current command list.

Since it was an instant brainless change, I figured I might as well issue a quick PR in case it's useful.